### PR TITLE
Product format fix

### DIFF
--- a/customers_refactor.py
+++ b/customers_refactor.py
@@ -21,6 +21,8 @@ for customer in customers:
     uniq_id = uuid.uuid5(uuid.NAMESPACE_OID, str(customer))
     new_dict['customers'][str(uniq_id)] = customer
 
+    customer['uniq_id'] = str(uniq_id)
+
     name = customer['customer_id']
     # b/c whoever designed this made the provider_id in a receipts object only have the name, not the location, so we can't know if the old data meant that this receipts was from the alberstons in King County or in Walla Walla, so I'm arbitrarily choosing the one that I loop over first to be the one that gets the receipt credit
     if name not in customer_id_to_hash_map:

--- a/fix_json.py
+++ b/fix_json.py
@@ -33,10 +33,14 @@ def parseItems(data, table_name, accessor):
             # if no data except for product name
             if(":" not in item):
                 keys = ["product"]
-            # product; unit weight: case lots: total weight
             if(";" in values[0]):
                 values = values[0].split(';') + values[1:3]
-                keys = ['product', 'unit_weight', 'case_lots', 'total_weight']
+                # product; unit weight: case lots: total weight
+                if(len(values) == 4):
+                    keys = ['product', 'unit_weight', 'case_lots', 'total_weight']
+                # product; funds_source; unit weight: case lots: total weight
+                elif(len(values) == 5):
+                    keys = ['product', 'funds_source', 'unit_weight', 'case_lots', 'total_weight']
             # create the new item as a dict
             json_dict = {keys[i] : values [i] for i in range(len(keys))}
             new_items.append(json_dict)

--- a/provider_refactor.py
+++ b/provider_refactor.py
@@ -21,6 +21,8 @@ for provider in providers:
     uniq_id = uuid.uuid5(uuid.NAMESPACE_OID, str(provider))
     new_dict['providers'][str(uniq_id)] = provider
 
+    provider['uniq_id'] = str(uniq_id)
+
     name = provider['provider_id']
     # b/c whoever designed this made the provider_id in a receipts object only have the name, not the location, so we can't know if the old data meant that this receipts was from the alberstons in King County or in Walla Walla, so I'm arbitrarily choosing the one that I loop over first to be the one that gets the receipt credit
     if name not in provider_id_to_hash_map:

--- a/shipments_refactor.py
+++ b/shipments_refactor.py
@@ -15,6 +15,10 @@ def give_uniq_ids(file_name, key):
 
     for obj in objects:
         uniq_id = uuid.uuid5(uuid.NAMESPACE_OID, str(obj))
+
+        # make objs self-referential
+        obj['uniq_id'] = str(uniq_id)
+
         new_dict[key][str(uniq_id)] = obj
 
     with open(file_name, 'w') as outfile:


### PR DESCRIPTION
Turns out there was a format for products in ship items and recieve items that wasn't accounted for originally, which involved the products funding source. This was causing some very weird front-end issues.